### PR TITLE
Add manual testing instructions

### DIFF
--- a/.cookiecutter/includes/HACKING.md
+++ b/.cookiecutter/includes/HACKING.md
@@ -1,0 +1,40 @@
+
+Testing Manually
+----------------
+
+To test it manually you can install your local development copy of
+`tox-recreate` into the local development environment of another tox-using
+project such as
+[cookiecutter-pypackage-test](https://github.com/hypothesis/cookiecutter-pypackage-test):
+
+1. Install a local development copy of `cookiecutter-pypackage-test` in a temporary directory:
+
+   ```terminal
+   git clone https://github.com/hypothesis/cookiecutter-pypackage-test.git /tmp/cookiecutter-pypackage-test
+   ```
+
+2. Run `cookiecutter-pypackage-test`'s `make sure` command to make sure that
+   everything is working and to trigger tox to create its `.tox/.tox`
+   venv:
+
+   ```terminal
+   make --directory "/tmp/cookiecutter-pypackage-test" sure
+   ```
+
+3. Uninstall the production copy of `tox-recreate` from `cookiecutter-pypackage-test`'s `.tox/.tox` venv:
+
+   ```terminal
+   /tmp/cookiecutter-pypackage-test/.tox/.tox/bin/pip uninstall tox-recreate
+   ```
+
+4. Install your local development copy of tox-recreate into `cookiecutter-pypackage-test`'s `.tox/.tox` venv:
+
+   ```terminal
+   /tmp/cookiecutter-pypackage-test/.tox/.tox/bin/pip install -e .
+   ```
+
+5. Now `cookiecutter-pypackage-test` commands will use your local development copy of `tox-recreate`:
+
+   ```terminal
+   make --directory "/tmp/cookiecutter-pypackage-test" test
+   ```

--- a/HACKING.md
+++ b/HACKING.md
@@ -100,3 +100,43 @@ To change the project's formatting, linting and test dependencies:
    ```
 
 3. Commit everything to git and send a pull request
+
+Testing Manually
+----------------
+
+To test it manually you can install your local development copy of
+`tox-recreate` into the local development environment of another tox-using
+project such as
+[cookiecutter-pypackage-test](https://github.com/hypothesis/cookiecutter-pypackage-test):
+
+1. Install a local development copy of `cookiecutter-pypackage-test` in a temporary directory:
+
+   ```terminal
+   git clone https://github.com/hypothesis/cookiecutter-pypackage-test.git /tmp/cookiecutter-pypackage-test
+   ```
+
+2. Run `cookiecutter-pypackage-test`'s `make sure` command to make sure that
+   everything is working and to trigger tox to create its `.tox/.tox`
+   venv:
+
+   ```terminal
+   make --directory "/tmp/cookiecutter-pypackage-test" sure
+   ```
+
+3. Uninstall the production copy of `tox-recreate` from `cookiecutter-pypackage-test`'s `.tox/.tox` venv:
+
+   ```terminal
+   /tmp/cookiecutter-pypackage-test/.tox/.tox/bin/pip uninstall tox-recreate
+   ```
+
+4. Install your local development copy of tox-recreate into `cookiecutter-pypackage-test`'s `.tox/.tox` venv:
+
+   ```terminal
+   /tmp/cookiecutter-pypackage-test/.tox/.tox/bin/pip install -e .
+   ```
+
+5. Now `cookiecutter-pypackage-test` commands will use your local development copy of `tox-recreate`:
+
+   ```terminal
+   make --directory "/tmp/cookiecutter-pypackage-test" test
+   ```


### PR DESCRIPTION
Add instructions to `HACKING.md` for how to test your local development version of this tox plugin in tox.

I don't think it makes sense to try to make this any easier (for example by trying to wrap the whole thing in a convenient `make` command): we only maintain a few tox plugins and they're all really simple ones that hopefully won't require much ongoing development. Maybe we can try just living with manual instructions for this in `HACKING.md` for now.

Once we merge this I'll add the same to the `tox.ini` files of [tox-faster](https://github.com/hypothesis/tox-faster) and [tox-envfile](https://github.com/hypothesis/tox-envfile). We could add this to the `pypackage` cookiecutter but it only applies to tox plugins so we'd have to add a `tox_plugin` boolean setting to `cookiecutter.json` (similar to other boolean settings like `console_script`). Might not be worth adding this to the cookiecutter since it only applies to tox plugins?